### PR TITLE
Displays Sony authorization error codes

### DIFF
--- a/resources/lib/sony.py
+++ b/resources/lib/sony.py
@@ -210,22 +210,19 @@ class SONY():
             'Accept-Encoding': 'gzip',
             "X-Requested-With": "com.snei.vue.atv"
         }
+        r = requests.get(url, headers=headers, verify=self.verify)
+        device_status = str(r.json()['body']['status'])
         
         if self.addon.getSetting(id='reqPayload') != '':
             headers['reauth'] = '1'
             headers['reqPayload'] = self.addon.getSetting(id='reqPayload')
-    
-            r = requests.get(url, headers=headers, verify=self.verify)
-                
-        if 'body' in r.json() and 'status' in r.json()['body']:
-            device_status = str(r.body['status'])
-                
-        if device_status = "UNAUTHORIZED":
+                                
+        if device_status == "UNAUTHORIZED":
             auth_error = r.json()['header']['error']['message']
             error_code = r.json()['header']['error']['code']
             self.addon.setSetting(id='auth_error', value=auth_error)
             self.addon.setSetting(id='error_code', value=error_code)
-            self.notification_msg(auth_error, "Error code:"error_code)
+            self.notification_msg(auth_error, "Error code: "+error_code)
             sys.exit()
 
         

--- a/resources/lib/sony.py
+++ b/resources/lib/sony.py
@@ -210,12 +210,26 @@ class SONY():
             'Accept-Encoding': 'gzip',
             "X-Requested-With": "com.snei.vue.atv"
         }
+        
         if self.addon.getSetting(id='reqPayload') != '':
             headers['reauth'] = '1'
             headers['reqPayload'] = self.addon.getSetting(id='reqPayload')
+    
+            r = requests.get(url, headers=headers, verify=self.verify)
+                
+        if 'body' in r.json() and 'status' in r.json()['body']:
+            device_status = str(r.body['status'])
+                
+        if device_status = "UNAUTHORIZED":
+            auth_error = r.json()['header']['error']['message']
+            error_code = r.json()['header']['error']['code']
+            self.addon.setSetting(id='auth_error', value=auth_error)
+            self.addon.setSetting(id='error_code', value=error_code)
+            self.notification_msg(auth_error, "Error code:"error_code)
+            sys.exit()
 
-        r = requests.get(url, headers=headers, verify=self.verify)
-        if 'reqPayload' in r.headers:
+        
+        elif 'reqPayload' in r.headers:
             req_payload = str(r.headers['reqPayload'])
             self.addon.setSetting(id='reqPayload', value=req_payload)
             auth_time = r.json()['header']['time_stamp']


### PR DESCRIPTION
Changed code to display authorize failed error codes. Will also save the error message and error code to settings.xml in the userdata folder. Codes are useful for login issues due to Sony account issues. Please let me know if there are any errors in the code as my PSVue account has been reset and I have no way of making it fail to test notification section of the code.