### PR TITLE
allows direct playback via kodi bookmark

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,6 +63,9 @@ elif mode == 200:
 elif mode == 300:
     live_tv()
 
+elif mode == 310:
+    play_live(channel_id)
+    
 elif mode == 350:
     on_demand(channel_id)
 

--- a/resources/lib/ps_vue.py
+++ b/resources/lib/ps_vue.py
@@ -44,6 +44,62 @@ def live_tv():
     json_source = get_json(EPG_URL + '/browse/items/now_playing/filter/all/sort/channel/offset/0/size/500')
     list_shows(json_source['body']['items'])
 
+def play_live(this_channel_id):
+    json_source = get_json(EPG_URL + '/browse/items/now_playing/filter/all/sort/channel/offset/0/size/500')
+    fanart = FANART
+    icon = ICON
+    for channel in json_source['body']['items']:
+        if 'channel' in channel:
+            title = channel['channel']['name']
+            channel_id = str(channel['channel']['channel_id'])
+        else:
+            title = channel['title']
+            channel_id = str(channel['id'])
+        
+        if this_channel_id == channel_id:
+
+            for image in channel['urls']:
+                if 'width' in image:
+                    if image['width'] == 600 or image['width'] == 440: icon = image['src']
+                    if image['width'] == 1920: fanart = image['src']
+                    if icon != ICON and fanart != FANART: break
+
+            genre = ''
+            for item in channel['genres']:
+                if genre != '': genre += ', '
+                genre += item['genre']
+
+            plot = get_dict_item('synopsis', channel)
+            season = get_dict_item('season_num', channel)
+            episode = get_dict_item('episode_num', channel)
+
+            channel_url = CHANNEL_URL + '/' + channel_id
+
+            info = {
+                'season':season,
+                'episode':episode,
+                'plot': plot,
+                'tvshowtitle': title,
+                'title': title,
+                'originaltitle': title,
+                'genre': genre
+            }
+
+            properties = {
+                'IsPlayable': 'true'
+            }
+
+            show_info = {
+                'channel_id': channel_id
+            }
+            
+            channel_url = CHANNEL_URL + '/' + channel_id
+            u = sys.argv[0] + "?url=" + urllib.quote_plus(channel_url) + "&mode=" + str(900)
+            liz = xbmcgui.ListItem(title)
+            liz.setInfo(type="Video", infoLabels=info)
+            liz.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
+            xbmc.Player().play(item=u, listitem=liz)
+
 def on_demand(channel_id):
     json_source = get_json(EPG_URL + '/details/channel/'+channel_id+'/popular/offset/0/size/500')
     list_shows(json_source['body']['popular'])


### PR DESCRIPTION
This allows skin authors, or whoever, to directly play a live tv channel and display associated box art.. e.g.

From a skin: 
```
PlayMedia("plugin://plugin.video.psvue/?mode=310&amp;channel_id=10283")
```

or via JSON RPC like:
```
http://192.168.1.XXX/jsonrpc?request={"jsonrpc":"2.0","method":"Addons.ExecuteAddon","params":{"addonid":"plugin.video.psvue","params": { "mode": "310", "channel_id": "10283"} }, "id": 2 }
```