### PR TITLE
- Fix error when listing shows

### DIFF
--- a/resources/lib/ps_vue.py
+++ b/resources/lib/ps_vue.py
@@ -276,7 +276,10 @@ def list_episode(show):
     if 'last_timecode' in show['airings'][0]:
         resumetime = str(show['airings'][0]['last_timecode'])
         xbmc.log("RESUME TIME = "+resumetime)
-        h,m,s = resumetime.split(':')
+        try:
+            h,m,s = resumetime.split(':')
+        except ValueError:
+            h,m,s,ms = resumetime.split(':')
         resumetime = str(int(h) * 3600 + int(m) * 60 + int(s))
 
     # xbmc.log("RESUME TIME IN Seconds = "+resumetime)


### PR DESCRIPTION
An error was being thrown when trying to watch certain shows:

`
10:06:14.302 T:1426924448   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.ValueError'>
                                            Error Contents: too many values to unpack
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.psvue/main.py", line 67, in <module>
                                                list_episodes(program_id)
                                              File "/storage/.kodi/addons/plugin.video.psvue/resources/lib/ps_vue.py", line 197, in list_episodes
                                                list_episode(show)
                                              File "/storage/.kodi/addons/plugin.video.psvue/resources/lib/ps_vue.py", line 279, in list_episode
                                                h,m,s = resumetime.split(':')
                                            ValueError: too many values to unpack
                                            -->End of Python script error report<--
`

This was due to the resumetime having milliseconds on it, in addition to hours, minutes, seconds. I added a try/except to catch the ValueError and split the resumetime into h,m,s,ms.