### PR TITLE
Optional alternate stream

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.psvue" name="PS Vue" version="2018.2.15" provider-name="eracknaphobia">
+<addon id="plugin.video.psvue" name="PS Vue" version="2018.3.24" provider-name="eracknaphobia">
   <requires>
-   <import addon="xbmc.python" version="2.24.0"/>
+   <import addon="xbmc.python" version="2.25.0"/>
    <import addon="script.module.requests" version="2.9.1"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="main.py">
@@ -13,9 +13,7 @@
     <description lang="en_GB">PlayStation™Vue is a TV service that streams live TV, movies, and sports on a variety of your favorite devices without a cable or satellite subscription.  With powerful features that allow you to save thousands of hours of your favorite shows without recording conflicts, and Premium channels that can be purchased individually or with a multi-channel plan, TV has never been the same. No annual contracts, no conflicts, no problems.</description>
     <disclaimer lang="en_GB">Requires a valid subscription to PS Vue which is currently only available in the US</disclaimer>
     <news>
-        - Kodi will now post resume times to sony servers, so show watch status and resume points are reflected in official apps
-        - Increased result size returned for kids, sports and episode sections
-        - Bug fixes and performance enhancements
+        - Re-enable inputstream adaptive
     </news>
     <language>en</language>
     <platform>all</platform>

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -180,3 +180,7 @@ msgstr ""
 msgctxt "#30224"
 msgid "All Channels"
 msgstr ""
+
+msgctxt "#30225"
+msgid "Force Alternate stream on Inputstream Adaptive"
+msgstr ""

--- a/resources/lib/ps_vue.py
+++ b/resources/lib/ps_vue.py
@@ -429,7 +429,13 @@ def get_stream(url, airing_id, channel_id, program_id, series_id, tms_id, title,
 
     r = requests.get(url, headers=headers, cookies=load_cookies(), verify=VERIFY)
     json_source = r.json()
-    stream_url = json_source['body']['video']
+    stream_url = ''
+
+    if ADDON.getSetting(id='inputstream') == 'false':
+        stream_url = json_source['body']['video']
+    elif ADDON.getSetting(id='inputstream') == 'true':
+        stream_url = json_source['body']['video_alt']
+
     headers = '|User-Agent='
     headers += 'Adobe Primetime/1.4 Dalvik/2.1.0 (Linux; U; Android 6.0.1 Build/MOB31H)'
     headers += '&Cookie=reqPayload=' + urllib.quote('"' + ADDON.getSetting(id='EPGreqPayload') + '"')
@@ -440,19 +446,12 @@ def get_stream(url, airing_id, channel_id, program_id, series_id, tms_id, title,
         listitem = xbmcgui.ListItem(title, plot, thumbnailImage=icon)
         listitem.setInfo(type="Video", infoLabels={'title': title, 'plot': plot})
         listitem.setMimeType("application/x-mpegURL")
+
     else:
         listitem = xbmcgui.ListItem()
         listitem.setMimeType("application/x-mpegURL")
 
-        
-    if ADDON.getSetting(id='inputstream') == 'true' and xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
-        stream_url = json_source['body']['video_alt']
-        listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
-        listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
-        listitem.setProperty('inputstream.adaptive.stream_headers', headers)
-        listitem.setProperty('inputstream.adaptive.license_key', headers)
-
-    elif ADDON.getSetting(id='inputstream') == 'false' and xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
+    if xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
         listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
         listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
         listitem.setProperty('inputstream.adaptive.stream_headers', headers)
@@ -460,6 +459,7 @@ def get_stream(url, airing_id, channel_id, program_id, series_id, tms_id, title,
     
     else:
         stream_url += headers
+
 
     listitem.setPath(stream_url)
 
@@ -552,6 +552,7 @@ def create_device_id():
 
 
 def utc_to_local(utc_dt):
+    # get integer timestamp to avoid precision lost
     offset = datetime.now() - datetime.utcnow()
     local_dt = utc_dt + offset + timedelta(seconds=1)
     return local_dt
@@ -567,11 +568,9 @@ def add_dir(name, mode, icon, fanart=None, channel_id=None):
     xbmcplugin.setContent(addon_handle, 'tvshows')
     return ok
 
-
 def add_sort_methods(handle):
     xbmcplugin.addSortMethod(handle=handle, sortMethod=xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE)
     xbmcplugin.addSortMethod(handle=handle, sortMethod=xbmcplugin.SORT_METHOD_UNSORTED)
-
 
 def add_show(name, mode, icon, fanart, info, show_info):
     u = sys.argv[0] + "?mode=" + str(mode)

--- a/resources/lib/ps_vue.py
+++ b/resources/lib/ps_vue.py
@@ -445,17 +445,22 @@ def get_stream(url, airing_id, channel_id, program_id, series_id, tms_id, title,
         listitem = xbmcgui.ListItem()
         listitem.setMimeType("application/x-mpegURL")
 
-    '''inputstreamCOND = str(json_source['body']['dai_method']) # Checks whether stream method is "mlbam" or "freewheel" or "none"
-
-    if  inputstreamCOND == 'mlbam' and xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):#Inputstream 2.1.15.0 update does not work with PSVue
-        stream_url = json_source['body']['video_alt'] # Uses alternate Sony stream to prevent Inputstream adaptive from crashing
+    if ADDON.getSetting(id='inputstream') == 'true' and xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
+        stream_url = json_source['body']['video_alt']
         listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
         listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
         listitem.setProperty('inputstream.adaptive.stream_headers', headers)
         listitem.setProperty('inputstream.adaptive.license_key', headers)
-    '''
-        
-    stream_url += headers
+
+    elif ADDON.getSetting(id='inputstream') == 'false' and xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
+        listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
+        listitem.setProperty('inputstream.adaptive.stream_headers', headers)
+        listitem.setProperty('inputstream.adaptive.license_key', headers)
+    
+    else:
+        stream_url += headers
+
 
     listitem.setPath(stream_url)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,6 +12,7 @@
     <setting id="recent_visible" type="bool" label="30220" default="true" />
     <setting id="featured_visible" type="bool" label="30221" default="true" />
     <setting id="search_visible" type="bool" label="30222" default="true" />
+    <setting id="inputstream" type="bool" label="30225" default="false" />
 
   </category>
     <!--Login-->

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,8 +12,6 @@
     <setting id="recent_visible" type="bool" label="30220" default="true" />
     <setting id="featured_visible" type="bool" label="30221" default="true" />
     <setting id="search_visible" type="bool" label="30222" default="true" />
-    <setting id="inputstream" type="bool" label="30225" default="false" />
-
   </category>
     <!--Login-->
     <category label="30000">
@@ -35,4 +33,5 @@
   <setting id="deviceId" type="text" default="" visible="false"/>
   <setting id="npsso" type="text" default="" visible="false"/>
   <setting id="default_profile" type="text" default="" visible="false"/>
+  <setting id="inputstream" type="bool" label="30225" default="false" />
 </settings>


### PR DESCRIPTION
Added optional bool setting to use the "video_alt" url with inputstream adaptive. LibreElec and inputstream 2.2.8 still doesn't like the video switching Sony does. But my OSX and inputstream 2.2.8 doesn't seem to have an issue with the default "video" url.