### PR TITLE
Changed the default EPG behavior

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
 <addon id="plugin.video.psvue" name="PS Vue" version="2019.9.28" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -47,8 +47,8 @@
     </category>
     <!--EPG-->
     <category label="30330">
-        <setting id="disable_epg" type="bool" label="30337"  default="false"/>
-        <setting id="epg_on_start" type="bool" label="30334"  default="true" enable="eq(-1,false)"/>
+        <setting id="disable_epg" type="bool" label="30337"  default="true"/>
+        <setting id="epg_on_start" type="bool" label="30334"  default="false" enable="eq(-1,false)"/>
         <setting id="epg_days" type="slider" label="30335" default="2" range="1,1,7" option="int" enable="eq(-2,false)"/>
         <setting id="epg_interval" type="slider" label="30336" default="1" range="1,1,24" option="int" enable="eq(-3,false)"/>
         <setting id="custom_directory" type="bool" label="30331"  default="false" enable="eq(-4,false)"/>


### PR DESCRIPTION
This hijacks the EPG regardless if there is another service using it.

Next commit maybe add a prompt on initial login if the user wants it enabled or perhaps instead of deleting all channels (other addons included) simply delete only the PSVue ones.